### PR TITLE
Dependency upgraded and builds fixed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,10 @@ language: node_js
 node_js:
   - lts/*
   - 6
-  # - node  TODO: restore this: failure occuring under latest v8.* of node
+  - node
 cache:
   directories:
     - node_modules
 script:
-  - CI=true npm test
-  - CI=false npm run build  # CI=false so warnings (from stellar-base>bindings) don't fail the build
+  - npm test
+  - npm run build

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "react-router-dom": "^4.1.1",
     "react-scripts": "1.0.10",
     "recompose": "^0.23.5",
-    "stellar-sdk": "chatch/js-stellar-sdk#patched"
+    "stellar-sdk": "chatch/js-stellar-sdk#upgrade_dependencies"
   },
   "devDependencies": {
     "bootstrap": "^3.3.7",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,13 @@
   "bugs": {
     "url": "https://github.com/chatch/stellarexplorer/issues"
   },
-  "keywords": ["stellar", "react", "ledger", "block explorer", "blockchain"],
+  "keywords": [
+    "stellar",
+    "react",
+    "ledger",
+    "block explorer",
+    "blockchain"
+  ],
   "engines": {
     "node": "6.x.x"
   },


### PR DESCRIPTION
Link to upgraded dependencies in js-xdr > stellar-base > stellar-sdk
Changes from this:
 - slightly reduced distribution size due to js-xdr import improvements
 - no longer get the bindings.js warning from stellar-base (so can remove CI flag from travis build)
 - no longer failing with latest version of node (not sure what caused this but not it's working fine)
