### PR TITLE
Add loading indicator

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -8,8 +8,29 @@
     <link rel="search" href="%PUBLIC_URL%/search.xml"
           title="Stellar Explorer" type="application/opensearchdescription+xml">
     <title>Stellar Explorer</title>
+
+    <style type="text/css">
+      body { background-color: #3c4452 !important; }
+      #loading-indicator { width:100%; height:100%; color:#07a2cc; font-size:1.6em; text-align:center; margin-top: 20%; }
+    </style>
   </head>
   <body>
-    <div id="root"></div>
+    <div id="root">
+      <div id="loading-indicator"></div>
+    </div>
+
+    <script type="text/javascript">
+      var count = 0;
+      const loadingIndicator = setInterval(() => {
+        const indicator = document.getElementById('loading-indicator');
+        if (!indicator) {
+          clearInterval(loadingIndicator);
+          return;
+        }
+
+        count++;
+        indicator.innerHTML = new Array(count % 10).join('.');
+      }, 100);
+    </script>
   </body>
 </html>


### PR DESCRIPTION
I looked into #72 and here's the thing: Most of the waiting time with a blank page is spent when initially loading the `bundle.js`, which contains react and the app. Since we would like to show the loading indicator during that time we can't reuse the `MDSpinner` component, since it is only available after React is loaded up.

As a compromise I suggest a minimal loading screen. I have intentionally left out any text, since the translations are also not yet available during the loading phase.

The `<div id="loading-screen></div>` is automatically overwritten once the app's `render()` method is invoked by react.
