### PR TITLE
Allow configuration of horizon backend address

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -61,6 +61,12 @@ table {
 .modal-body img {
   margin-top: 10px;
 }
+.modal-body input[type=text] {
+  width: 100%;
+}
+.modal-body input {
+  margin-bottom: 10px;
+}
 
 /*
  * Bootstrap components and styles
@@ -345,7 +351,7 @@ ul.navbar-nav .divider-vertical {
   outline: none;
 }
 
-.Network-Selector button:not(:first-child) {
+.Network-Selector button:not(:first-child), .Network-Selector span:not(:first-child) {
   margin-left: 5px;
 }
 

--- a/src/components/layout/Header.js
+++ b/src/components/layout/Header.js
@@ -39,8 +39,10 @@ class Header extends React.Component {
           </Navbar.Form>
           <Navbar.Form pullRight>
             <NetworkSelector
-              network={this.props.network}
-              switcher={this.props.networkSwitcher}
+              networkAddress={this.props.networkAddress}
+              networkType={this.props.networkType}
+              switchNetworkType={this.props.switchNetworkType}
+              setNetworkAddress={this.props.setNetworkAddress}
             />
           </Navbar.Form>
           <Nav>

--- a/src/components/layout/NetworkSelector.js
+++ b/src/components/layout/NetworkSelector.js
@@ -1,25 +1,32 @@
 import React from 'react'
 import {networks} from '../../lib/stellar'
+import CustomNetworkButton from '../shared/CustomNetworkButton'
 
-const NetworkButton = ({network, selectedNetwork, switcher}) =>
+const NetworkButton = ({networkType, selectedNetworkType, switchNetworkType}) =>
   <button
-    className={network === selectedNetwork ? 'is-active' : 'is-inactive'}
-    onClick={e => switcher(network)}
+    className={networkType === selectedNetworkType ? 'is-active' : 'is-inactive'}
+    onClick={e => switchNetworkType(networkType)}
   >
-    {network.toUpperCase()}
+    {networkType.toUpperCase()}
   </button>
 
 const NetworkSelector = props =>
   <div className="Network-Selector">
-    {[networks.public, networks.test].map(network =>
+    {[networks.public, networks.test].map(networkType =>
       <NetworkButton
-        key={network}
-        hide={networks[network].hide}
-        network={network}
-        selectedNetwork={props.network}
-        switcher={props.switcher}
+        key={networkType}
+        hide={networks[networkType].hide}
+        networkType={networkType}
+        selectedNetworkType={props.networkType}
+        switchNetworkType={props.switchNetworkType}
       />
     )}
+    <CustomNetworkButton
+      key="custom-network"
+      networkAddress={props.networkAddress}
+      networkType={props.networkType}
+      setNetworkAddress={props.setNetworkAddress}
+    />
   </div>
 
 export default NetworkSelector

--- a/src/components/shared/CustomNetworkButton.js
+++ b/src/components/shared/CustomNetworkButton.js
@@ -1,0 +1,190 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import Modal from 'react-bootstrap/lib/Modal'
+import {FormattedMessage} from 'react-intl'
+
+const networkAddresses = [
+  'https://horizon.stellar.org',
+  'https://stellar-api.wancloud.io',
+  'https://api.chinastellar.com',
+];
+
+/**
+ * Button that reveals modal window where the Horizon server address can
+ * be configured.
+ */
+const CustomNetworkButton = ({handleClickFn}) =>
+  <button
+    className="is-inactive"
+    onClick={handleClickFn}>
+    <FormattedMessage id="network.set-custom" />
+  </button>
+
+CustomNetworkButton.propTypes = {
+  handleClickFn: PropTypes.func.isRequired,
+}
+
+const ResourceModalBody = ({networkAddress, inputValue, dropdownValue, networkType,
+                            handleSubmitFn, handleInputChangeFn, handleDropdownChangeFn}) => {
+  return (
+    <form onSubmit={handleSubmitFn}>
+      <div>
+        <h4><FormattedMessage id="network.current" /></h4>
+        <FormattedMessage id={'network.' + networkType} /><br />
+        <pre style={{marginTop: 5}}>{networkAddress}</pre><br />
+      </div>
+
+      <div>
+        <h4><FormattedMessage id="network.change-here" /></h4>
+        <FormattedMessage id="network.choose" /><br />
+        <select id="networkDropdown" onChange={handleDropdownChangeFn} value={dropdownValue}>
+          <option></option>
+          {networkAddresses.map(address => address !== networkAddress && (
+            <option>{address}</option>
+            ))
+          }
+        </select><br/><br/>
+
+        <FormattedMessage id="network.or-custom" /><br />
+        <input
+          style={{marginTop: 5}}
+          type="text"
+          onChange={handleInputChangeFn}
+          value={inputValue}
+          /><br/>
+
+        <FormattedMessage id="save">
+          {msg => (<input type="submit" value={msg} />)}
+        </FormattedMessage>
+      </div>
+    </form>
+  )
+}
+
+const ResourceModal = props => (
+  <Modal id="networkModal" show={props.show} onHide={props.handleCloseFn}>
+    <Modal.Header closeButton>
+      <Modal.Title id="contained-modal-title-lg" style={{color: '#dce2ec'}}>
+        <FormattedMessage id="network.address" />
+      </Modal.Title>
+    </Modal.Header>
+    <Modal.Body>
+      <ResourceModalBody {...props} />
+    </Modal.Body>
+  </Modal>
+)
+
+ResourceModal.propTypes = {
+  handleCloseFn: PropTypes.func.isRequired,
+  handleSubmitFn: PropTypes.func.isRequired,
+  handleDropdownChangeFn: PropTypes.func.isRequired,
+  dropdownValue: PropTypes.string.isRequired,
+  inputValue: PropTypes.string.isRequired,
+  show: PropTypes.bool.isRequired,
+}
+
+class ResourceModalContainer extends React.Component {
+  render() {
+    return (
+      <ResourceModal
+        handleCloseFn={this.props.handleCloseFn}
+        handleSubmitFn={this.props.handleSubmitFn}
+        handleDropdownChangeFn={this.props.handleDropdownChangeFn}
+        handleInputChangeFn={this.props.handleInputChangeFn}
+        dropdownValue={this.props.dropdownValue}
+        inputValue={this.props.inputValue}
+        networkAddress={this.props.networkAddress}
+        networkType={this.props.networkType}
+        show={this.props.show}
+      />
+    )
+  }
+}
+
+ResourceModalContainer.propTypes = {
+  handleCloseFn: PropTypes.func.isRequired,
+  show: PropTypes.bool.isRequired,
+}
+
+class CustomNetworkButtonWithResourceModal extends React.Component {
+  constructor(props, context) {
+    super(props, context)
+
+    this.handleClick = this.handleClick.bind(this)
+    this.handleClose = this.handleClose.bind(this)
+    this.handleSubmit = this.handleSubmit.bind(this);
+    this.handleDropdownChange = this.handleDropdownChange.bind(this);
+    this.handleInputChange = this.handleInputChange.bind(this);
+
+    this.state = {
+      show: false,
+      dropdownValue: '',
+      inputValue: this.props.networkAddress,
+    }
+  }
+
+  handleSubmit(event) {
+    event.preventDefault();
+
+    const input = this.state.inputValue;
+    const dropdown = this.state.dropdownValue;
+    const newNetworkAddress = dropdown !== '' ? dropdown : input;
+    if (newNetworkAddress !== this.props.networkAddress) {
+      this.props.setNetworkAddress(newNetworkAddress);
+    }
+  }
+
+  handleDropdownChange(event) {
+    const newNetworkAddress = event.target.value;
+    this.setState({dropdownValue: newNetworkAddress});
+    this.props.setNetworkAddress(newNetworkAddress);
+  }
+
+  handleInputChange(event) {
+    const newNetworkAddress = event.target.value;
+    this.setState({inputValue: newNetworkAddress});
+  }
+
+  handleClose() {
+    this.setState({show: false})
+  }
+
+  handleClick(event) {
+    event.preventDefault()
+    this.setState({show: true})
+  }
+
+  render() {
+    return (
+      <span>
+        <CustomNetworkButton
+          network={this.props.network}
+          networkAddress={this.networkAddress}
+          handleClickFn={this.handleClick}
+        />
+        {this.state.show && (
+          <ResourceModalContainer
+            handleSubmitFn={this.handleSubmit}
+            handleDropdownChangeFn={this.handleDropdownChange}
+            handleInputChangeFn={this.handleInputChange}
+            dropdownValue={this.state.dropdownValue}
+            inputValue={this.state.inputValue}
+            handleCloseFn={this.handleClose}
+            setNetworkAddress={this.props.setNetworkAddress}
+            networkAddress={this.props.networkAddress}
+            networkType={this.props.networkType}
+            show={this.state.show}
+          />
+        )}
+      </span>
+    )
+  }
+}
+
+CustomNetworkButtonWithResourceModal.propTypes = {
+  setNetworkAddress: PropTypes.func.isRequired,
+  networkAddress: PropTypes.string.isRequired,
+  networkType: PropTypes.string.isRequired,
+}
+
+export default CustomNetworkButtonWithResourceModal

--- a/src/components/shared/InsecureNetworkError.js
+++ b/src/components/shared/InsecureNetworkError.js
@@ -1,0 +1,29 @@
+import React from 'react'
+import Grid from 'react-bootstrap/lib/Grid'
+import Row from 'react-bootstrap/lib/Row'
+import {FormattedMessage} from 'react-intl'
+
+class InsecureNetworkError extends React.Component {
+  render() {
+    const uri = this.props.location.search.replace('?', '');
+    return (
+      <Grid>
+        <Row>
+          <h3>
+            <FormattedMessage id="error.occurred" />
+            {uri ? (
+              <FormattedMessage id="error.insecure-network.uri" values={{uri: uri}} />
+            ) : (
+              <FormattedMessage
+                id="error.insecure-network"
+              />
+            )}
+          </h3>
+          <FormattedMessage id="error.insecure-network.reason" />
+        </Row>
+      </Grid>
+    )
+  }
+}
+
+export default InsecureNetworkError

--- a/src/languages/en.json
+++ b/src/languages/en.json
@@ -41,6 +41,10 @@
   "error.network":
     "Network error occurred. Check your connection or check the browser console for messages.",
   "error.unknown": "Apologies, something went wrong ... ",
+  "error.occurred": "An error occurred: ",
+  "error.insecure-network": "The horizon address is insecure!",
+  "error.insecure-network.uri": "The horizon address \"{uri}\" is insecure!",
+  "error.insecure-network.reason": "You probably tried to set a horizon address with the prefix \"http\" instead of \"https\". Stellar allows \"http\" only for testnets.",
 
   "exchanges": "Exchanges",
 
@@ -87,6 +91,15 @@
 
   "name": "Name",
   "network": "Network",
+  "network.current": "Current Network",
+  "network.set-custom": "Set Custom Network",
+  "network.address": "Network Address",
+  "network.choose": "Choose from the list:",
+  "network.or-custom": "…or enter a custom address:",
+  "network.change-here": "Set a different Network",
+  "network.public": "You are currently using this Public Horizon Instance:",
+  "network.test": "You are currently using this Testnet Horizon Instance:",
+  "network.local": "You are currently using this Local Horizon Instance:",
   "offer": "Offer",
   "offers": "Offers",
 
@@ -139,6 +152,7 @@
   "recipient": "Recipient",
   "remove": "Remove",
 
+  "save": "Save",
   "search.placeHolder": "Search by Account / Transaction / Anchor / ...",
   "sell": "Sell",
   "seller": "Seller",

--- a/src/lib/stellar/__tests__/networks.test.js
+++ b/src/lib/stellar/__tests__/networks.test.js
@@ -1,23 +1,23 @@
-import networks, {hostnameToNetwork} from '../networks'
+import networks, {hostnameToNetworkType} from '../networks'
 
 describe('hostnameToNetwork', () => {
-  it('detects network correctly from the hostname', () => {
+  it('detects network type correctly from the hostname', () => {
     // public network
-    expect(hostnameToNetwork('steexp.com')).toEqual(networks.public)
+    expect(hostnameToNetworkType('steexp.com')).toEqual(networks.public)
 
     // test network
-    expect(hostnameToNetwork('testnet.steexp.com')).toEqual(networks.test)
+    expect(hostnameToNetworkType('testnet.steexp.com')).toEqual(networks.test)
 
     // localhost for development
-    expect(hostnameToNetwork('localnet.local')).toEqual(networks.local)
-    expect(hostnameToNetwork('testnet.local')).toEqual(networks.test)
-    expect(hostnameToNetwork('publicnet.local')).toEqual(networks.public)
+    expect(hostnameToNetworkType('localnet.local')).toEqual(networks.local)
+    expect(hostnameToNetworkType('testnet.local')).toEqual(networks.test)
+    expect(hostnameToNetworkType('publicnet.local')).toEqual(networks.public)
 
     // unknown hosts default to local
-    expect(hostnameToNetwork()).toEqual(networks.local)
-    expect(hostnameToNetwork('')).toEqual(networks.local)
-    expect(hostnameToNetwork('localhost')).toEqual(networks.local)
-    expect(hostnameToNetwork('0.0.0.0')).toEqual(networks.local)
-    expect(hostnameToNetwork('not.steexp.com')).toEqual(networks.local)
+    expect(hostnameToNetworkType()).toEqual(networks.local)
+    expect(hostnameToNetworkType('')).toEqual(networks.local)
+    expect(hostnameToNetworkType('localhost')).toEqual(networks.local)
+    expect(hostnameToNetworkType('0.0.0.0')).toEqual(networks.local)
+    expect(hostnameToNetworkType('not.steexp.com')).toEqual(networks.local)
   })
 })

--- a/src/lib/stellar/networks.js
+++ b/src/lib/stellar/networks.js
@@ -4,7 +4,7 @@ const networks = {
   local: 'local',
 }
 
-const hostnameToNetwork = hostname => {
+const hostnameToNetworkType = hostname => {
   if (hostname === 'steexp.com' || hostname === 'publicnet.local')
     return networks.public
   else if (hostname === 'testnet.steexp.com' || hostname === 'testnet.local')
@@ -12,4 +12,4 @@ const hostnameToNetwork = hostname => {
   else return networks.local
 }
 
-export {networks as default, hostnameToNetwork}
+export {networks as default, hostnameToNetworkType}


### PR DESCRIPTION
Hi there @chatch,

I have worked on #26 and this is the result so far. It's possible to configure the horizon backend address now. Depending on the tab PUBLIC/TEST the network address is considered either the address of a public or a testnet (and either `usePublicNetwork()` or `useTestNetwork()` is called).

What I haven't implemented yet is your idea of detecting the country on first load and adapt the horizon address accordingly. I ran into this when implementing it: https://www.npmjs.com/package/geoip-country is a server side package, so we would need to run an additional express server (or something similar) to provide a route which resolves an IP to a geolocation. I'm not sure how I feel about an additional server, which would run under an additional port number. What are your thoughts?

And another question: How would you like to have translations handled? Is it ok to add the i18n strings only to `en.json` or would you also add them to the other language files to make it visible which translations are missing?

I'm looking forward to hear from you :-).