### PR TITLE
Be resilient to unrecognized operation types

### DIFF
--- a/src/components/operations/Operation.js
+++ b/src/components/operations/Operation.js
@@ -18,6 +18,7 @@ import Offer from './Offer'
 import PathPayment from './PathPayment'
 import Payment from './Payment'
 import SetOptions from './SetOptions'
+import Unrecognized from './Unrecognized'
 
 const opTypeComponentMap = {
   account_merge: AccountMerge,
@@ -47,7 +48,7 @@ const opTypeComponentMap = {
 const opTypes = Object.keys(opTypeComponentMap)
 
 const SubOperation = ({op}) => {
-  const SubOpComponent = opTypeComponentMap[op.type]
+  const SubOpComponent = opTypeComponentMap[op.type] || Unrecognized
   return <SubOpComponent {...op} />
 }
 

--- a/src/components/operations/Unrecognized.js
+++ b/src/components/operations/Unrecognized.js
@@ -1,0 +1,11 @@
+import React from 'react'
+import {FormattedMessage} from 'react-intl'
+
+const Unrecognized = ({type}) => <FormattedMessage
+  id="operation.unrecognized"
+  values={{
+    type: type,
+  }}
+/>
+
+export default Unrecognized

--- a/src/languages/en.json
+++ b/src/languages/en.json
@@ -134,6 +134,7 @@
   "operation.trust": "Trust {trustee} issuing {assetCode}",
   "operation.trust.allow": " [authorize: {authorize}, trustor: {trustor}]",
   "operation.trust.change": " with limit {limit}",
+  "operation.unrecognized": "Operation {type}",
 
   "optional": "Optional",
   "order.amount": "Amount",

--- a/src/languages/ru.json
+++ b/src/languages/ru.json
@@ -98,6 +98,7 @@
   "operation.trust": "Доверие {trustee} выпускающему {assetCode}",
   "operation.trust.allow": " [authorize: {authorize}, trustor: {trustor}]",
   "operation.trust.change": " с лимитом {limit}",
+  "operation.unregoznied": "Операция {type}",
 
   "optional": "Необязательно",
   "order.amount": "Сумма",

--- a/src/languages/vi.json
+++ b/src/languages/vi.json
@@ -97,6 +97,7 @@
   "operation.trust": "Tin tưởng {trustee} phát hành {assetCode}",
   "operation.trust.allow": " [authorize: {authorize}, trustor: {trustor}]",
   "operation.trust.change": " với giới hạn {limit}",
+  "operation.unregoznied": "Hoạt động {type}",
 
   "optional": "Không bắt buộc",
   "order.amount": "Số tiền",

--- a/src/languages/zh.json
+++ b/src/languages/zh.json
@@ -130,6 +130,7 @@
   "operation.trust": "信任 {trustee} 发行 {assetCode}",
   "operation.trust.allow": " [authorize: {authorize}, trustor: {trustor}]",
   "operation.trust.change": "至限额 {limit}",
+  "operation.unregoznied": "操作 {type}",
 
   "optional": "可选",
   "order.amount": "数量",


### PR DESCRIPTION
### What
Display a generic message for operations that are unrecognized.

### Why
This explorer supports being pointed at any Horizon, which makes it uniquely useful for use with Horizon instances running experiments or logic that is not yet released to testnet or pubnet. For the most part the explorer is very resilient to new flags, or other new fields that get added to Horizon over time. It will even display them in the UI without any changes needed. However, if a new operation is added to Horizon that causes the explorer to error and no page displays. This small change allows the explorer to keep working and displays a generic message to indicate what operation the operation is.

Close #197 