### PR TITLE
fix eslint rule - rm comma-dangle 

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -10,7 +10,6 @@
   "rules": {
     "react/jsx-wrap-multilines": "off",
     "jsx-a11y/anchor-has-content": "off",
-    "comma-dangle": ["warn", "always-multiline"],
     "quotes": ["warn", "single"],
     "semi": ["warn", "never"],
     "prettier/prettier": [


### PR DESCRIPTION
Applied the linter with `npm run lint:fix`.
Then got the following error on `npm run dev`.
The server is up and running though.

Realized a comma is added to a weird place due to the `"comma-dangle": ["warn", "always-multiline"]` eslint config.
Removed it (then the default prettier rule is applied), then the error has gone.

```
$ npm run dev
:
:
💿  remix dev

 warn  The `remix dev` changing in v2
┃ You can use the `v2_dev` future flag to opt-in early.
┃ -> https://remix.run/docs/en/main/pages/v2#dev-server
┗
💿 Building...
✘ [ERROR] Expected ")" but found "}"

    app/components/layout/NetworkSelector.tsx:71:5:
      71 │     )}
         │      ^
         ╵      )


✘ [ERROR] Build failed with 1 error:
app/components/layout/NetworkSelector.tsx:71:5: ERROR: Expected ")" but found "}" [plugin css-bundle-update-plugin]

    app/root.tsx:4:30:
      4 │ import { cssBundleHref } from '@remix-run/css-bundle';
        ╵                               ~~~~~~~~~~~~~~~~~~~~~~~

  This error came from the "onLoad" callback registered here:

    node_modules/@remix-run/dev/dist/compiler/plugins/cssBundlePlugin.js:47:12:
      47 │       build.onLoad({
         ╵             ~~~~~~

    at setup (/Users/ryuji.eguchi/src/github.com/chatch/stellarexplorer/node_modules/@remix-run/dev/dist/compiler/plugins/cssBundlePlugin.js:47:13)
    at handlePlugins (/Users/ryuji.eguchi/src/github.com/chatch/stellarexplorer/node_modules/esbuild/lib/main.js:1279:21)
    at processTicksAndRejections (node:internal/process/task_queues:95:5)


💿 Rebuilt in 985ms
Remix App Server started at http://localhost:3000 (http://192.168.88.152:3000/)
```
 