### PR TITLE
Use remix run eslint config

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,5 +1,10 @@
 {
-  "extends": ["react-app", "prettier"],
+  "extends": [
+    "@remix-run/eslint-config",
+    "@remix-run/eslint-config/jest-testing-library",
+    "react-app",
+    "prettier"
+  ],
   "plugins": ["prettier"],
   "overrides": [
     {

--- a/app/components/EffectTable.tsx
+++ b/app/components/EffectTable.tsx
@@ -1,7 +1,8 @@
 import Table from 'react-bootstrap/Table'
 import { FormattedMessage } from 'react-intl'
 
-import Effect, { EffectProps } from './Effect'
+import type { EffectProps } from './Effect'
+import Effect from './Effect'
 
 interface EffectTableProps {
   records: ReadonlyArray<EffectProps>

--- a/app/components/layout/Header.tsx
+++ b/app/components/layout/Header.tsx
@@ -9,7 +9,7 @@ import { LinkContainer } from 'react-router-bootstrap'
 import logoImg from '../../img/logo.png'
 import LanguageSelector from './LanguageSelector'
 import NetworkSelector from './NetworkSelector'
-import { NetworkKey } from '~/lib/stellar/networks'
+import type { NetworkKey } from '~/lib/stellar/networks'
 
 interface HeaderProps {
   languageSwitcher: MouseEventHandler

--- a/app/components/layout/NetworkSelector.tsx
+++ b/app/components/layout/NetworkSelector.tsx
@@ -1,6 +1,6 @@
 import { networks } from '../../lib/stellar'
 import CustomNetworkButton from '../shared/CustomNetworkButton'
-import { NetworkKey } from '~/lib/stellar/networks'
+import type { NetworkKey } from '~/lib/stellar/networks'
 
 const HOME_PUBLIC = 'https://steexp.com'
 const HOME_TESTNET = 'https://testnet.steexp.com'

--- a/app/components/operations/AllowTrust.tsx
+++ b/app/components/operations/AllowTrust.tsx
@@ -1,6 +1,7 @@
 import { FormattedMessage } from 'react-intl'
 import AccountLink from '../shared/AccountLink'
-import Trust, { TrustProps } from './Trust'
+import type { TrustProps } from './Trust'
+import Trust from './Trust'
 
 export interface AllowTrustProps extends TrustProps {
   authorize: string

--- a/app/components/operations/ChangeTrust.tsx
+++ b/app/components/operations/ChangeTrust.tsx
@@ -1,4 +1,5 @@
-import Trust, { TrustProps } from './Trust'
+import type { TrustProps } from './Trust'
+import Trust from './Trust'
 import { FormattedMessage } from 'react-intl'
 
 interface ChangeTrustProps extends TrustProps {

--- a/app/components/operations/Operation.tsx
+++ b/app/components/operations/Operation.tsx
@@ -7,7 +7,8 @@ import RelativeTime from '../shared/RelativeTime'
 import TransactionHash from '../shared/TransactionHash'
 
 import AccountMerge from './AccountMerge'
-import AllowTrust, { AllowTrustProps } from './AllowTrust'
+import type { AllowTrustProps } from './AllowTrust'
+import AllowTrust from './AllowTrust'
 import BumpSequence from './BumpSequence'
 import ChangeTrust from './ChangeTrust'
 import {
@@ -18,15 +19,19 @@ import {
   ClawbackOperation,
   ClawbackClaimableBalanceOperation,
 } from './Clawback'
-import CreateAccount, { CreateAccountProps } from './CreateAccount'
+import type { CreateAccountProps } from './CreateAccount'
+import CreateAccount from './CreateAccount'
 import Inflation from './Inflation'
 import InvokeHostFunction from './InvokeHostFunction'
 import { LiquidityPoolDeposit, LiquidityPoolWithdraw } from './LiquidityPool'
-import ManageData, { ManageDataProps } from './ManageData'
+import type { ManageDataProps } from './ManageData'
+import ManageData from './ManageData'
 import Offer from './Offer'
-import PathPayment, { PathPaymentProps } from './PathPayment'
+import type { PathPaymentProps } from './PathPayment'
+import PathPayment from './PathPayment'
 import Payment from './Payment'
-import SetOptions, { SetOptionsProps } from './SetOptions'
+import type { SetOptionsProps } from './SetOptions'
+import SetOptions from './SetOptions'
 import SetTrustLineFlags from './SetTrustLineFlags'
 import {
   BeginSponsoringFutureReserves,

--- a/app/components/operations/PathPayment.tsx
+++ b/app/components/operations/PathPayment.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
-import Payment, { PaymentProps } from './Payment'
+import type { PaymentProps } from './Payment'
+import Payment from './Payment'
 import Asset from '../shared/Asset'
 import { FormattedMessage } from 'react-intl'
 

--- a/app/components/operations/Payment.tsx
+++ b/app/components/operations/Payment.tsx
@@ -1,4 +1,5 @@
-import React, { PropsWithChildren } from 'react'
+import type { PropsWithChildren } from 'react'
+import React from 'react'
 import { FormattedMessage } from 'react-intl'
 import Asset from '../shared/Asset'
 import AccountLink from '../shared/AccountLink'

--- a/app/components/operations/Trust.tsx
+++ b/app/components/operations/Trust.tsx
@@ -1,4 +1,4 @@
-import { PropsWithChildren } from 'react'
+import type { PropsWithChildren } from 'react'
 import AccountLink from '../shared/AccountLink'
 import { FormattedMessage } from 'react-intl'
 

--- a/app/components/shared/BackendResourceBadgeButton.tsx
+++ b/app/components/shared/BackendResourceBadgeButton.tsx
@@ -1,4 +1,5 @@
-import { MouseEventHandler, useEffect, useState } from 'react'
+import type { MouseEventHandler } from 'react'
+import { useEffect, useState } from 'react'
 import JSONPretty from 'react-json-pretty'
 import Button from 'react-bootstrap/Button'
 import Modal from 'react-bootstrap/Modal'

--- a/app/components/shared/CustomNetworkButton.tsx
+++ b/app/components/shared/CustomNetworkButton.tsx
@@ -1,9 +1,5 @@
-import React, {
-  ChangeEventHandler,
-  FormEvent,
-  FormEventHandler,
-  useState,
-} from 'react'
+import type { ChangeEventHandler, FormEvent, FormEventHandler } from 'react'
+import React, { useState } from 'react'
 import Modal from 'react-bootstrap/Modal'
 import { FormattedMessage } from 'react-intl'
 

--- a/app/components/shared/Paging.tsx
+++ b/app/components/shared/Paging.tsx
@@ -1,4 +1,4 @@
-import { MouseEventHandler } from 'react'
+import type { MouseEventHandler } from 'react'
 import PagingControls from './PagingControls'
 import { useNavigate } from '@remix-run/react'
 

--- a/app/components/shared/PagingControls.tsx
+++ b/app/components/shared/PagingControls.tsx
@@ -1,4 +1,4 @@
-import { MouseEventHandler } from 'react'
+import type { MouseEventHandler } from 'react'
 import { FormattedMessage } from 'react-intl'
 
 interface PagingControlsProps {

--- a/app/components/shared/__tests__/LumensRates.test.js
+++ b/app/components/shared/__tests__/LumensRates.test.js
@@ -10,7 +10,7 @@ describe('LumensRates', () => {
   it('render positive change in rate', () => {
     const rate = shallow(<LumensRates change="2.1" usd="0.020" />)
     const changeEl = rate.find('span[style]')
-    expect(changeEl.props().style.color).toEqual('#00c292')
+    expect(changeEl.props()).toHaveStyle({ color: '#00c292' })
     expect(rate.getElements()).toMatchInlineSnapshot(`
     Array [
       <span>
@@ -34,7 +34,7 @@ describe('LumensRates', () => {
   it('render negative change in rate', () => {
     const rate = shallow(<LumensRates change="-1.52" usd="0.025" />)
     const changeEl = rate.find('span[style]')
-    expect(changeEl.props().style.color).toEqual('#fb9678')
+    expect(changeEl.props()).toHaveStyle({ color: '#fb9678' })
     expect(rate.getElements()).toMatchInlineSnapshot(`
     Array [
       <span>

--- a/app/data/__tests__/known_accounts.test.js
+++ b/app/data/__tests__/known_accounts.test.js
@@ -1,3 +1,4 @@
+/* eslint-disable testing-library/await-async-query */
 import accounts from '../known_accounts'
 import { isPublicKey } from '../../lib/stellar/utils'
 

--- a/app/lib/loader-util.ts
+++ b/app/lib/loader-util.ts
@@ -1,4 +1,5 @@
-import { LoaderArgs, TypedResponse, json } from '@remix-run/node'
+import type { LoaderArgs, TypedResponse } from '@remix-run/node'
+import { json } from '@remix-run/node'
 import { requestToServer } from './stellar/server'
 import * as serverRequestUtils from './stellar/server_request_utils'
 

--- a/app/lib/stellar/contracts.ts
+++ b/app/lib/stellar/contracts.ts
@@ -1,5 +1,6 @@
 import { Contract } from 'soroban-client'
-import { SorobanServer, xdr } from '../stellar'
+import type { SorobanServer } from '../stellar'
+import { xdr } from '../stellar'
 import { hexStringToBytes } from '../utils'
 import { scValToString } from './xdr_scval_utils'
 import ContractIdInvalid from '../error/ContractIdInvalid'

--- a/app/lib/stellar/server_request_utils.ts
+++ b/app/lib/stellar/server_request_utils.ts
@@ -18,8 +18,8 @@ import type { PaymentCallBuilder } from 'stellar-sdk/lib/payment_call_builder'
 import type { TradesCallBuilder } from 'stellar-sdk/lib/trades_call_builder'
 import { isPublicKey, isFederatedAddress, isMuxedAddress } from './utils'
 import type { AccountCallBuilder } from 'stellar-sdk/lib/account_call_builder'
-import { TransactionCallBuilder } from 'stellar-sdk/lib/transaction_call_builder'
-import { OfferCallBuilder } from 'stellar-sdk/lib/offer_call_builder'
+import type { TransactionCallBuilder } from 'stellar-sdk/lib/transaction_call_builder'
+import type { OfferCallBuilder } from 'stellar-sdk/lib/offer_call_builder'
 import AccountTypeUnrecognizedException from '../error/AccountTypeUnrecognizedException'
 
 interface PageOptions {

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -3,7 +3,7 @@ import { useState } from 'react'
 import { IntlProvider } from 'react-intl'
 import { cssBundleHref } from '@remix-run/css-bundle'
 import { json } from '@remix-run/node'
-import type { LoaderArgs, type LinksFunction } from '@remix-run/node'
+import type { LoaderArgs, LinksFunction } from '@remix-run/node'
 import {
   Links,
   LiveReload,

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -2,7 +2,8 @@ import type { PropsWithChildren } from 'react'
 import { useState } from 'react'
 import { IntlProvider } from 'react-intl'
 import { cssBundleHref } from '@remix-run/css-bundle'
-import { json, LoaderArgs, type LinksFunction } from '@remix-run/node'
+import { json } from '@remix-run/node'
+import type { LoaderArgs, type LinksFunction } from '@remix-run/node'
 import {
   Links,
   LiveReload,
@@ -36,7 +37,7 @@ import zhHantMessages from './lib/languages/zh-Hant.json'
 import { requestToNetworkDetails } from './lib/stellar/networks'
 import { storageInit } from './lib/utils'
 import SearchBox from './SearchBox'
-import { V2_ErrorBoundaryComponent } from '@remix-run/react/dist/routeModules'
+import type { V2_ErrorBoundaryComponent } from '@remix-run/react/dist/routeModules'
 import { NotFoundError } from 'stellar-sdk'
 
 export const links: LinksFunction = () => [

--- a/app/routes/account.$accountId.balances.tsx
+++ b/app/routes/account.$accountId.balances.tsx
@@ -1,16 +1,15 @@
-import { LoaderArgs, json } from '@remix-run/node'
+import type { LoaderArgs } from '@remix-run/node'
+import { json } from '@remix-run/node'
 import { useLoaderData, useParams } from '@remix-run/react'
 import { useEffect } from 'react'
 import { Table } from 'react-bootstrap'
 import { FormattedMessage } from 'react-intl'
-import { Horizon } from 'stellar-sdk'
+import type { Horizon } from 'stellar-sdk'
 import Asset from '~/components/shared/Asset'
 import FormattedAmount from '~/components/shared/FormattedAmount'
 import { requestToServer } from '~/lib/stellar/server'
-import {
-  LoadAccountResult,
-  loadAccount,
-} from '~/lib/stellar/server_request_utils'
+import type { LoadAccountResult } from '~/lib/stellar/server_request_utils'
+import { loadAccount } from '~/lib/stellar/server_request_utils'
 import { setTitle } from '~/lib/utils'
 
 type Balance = Pick<

--- a/app/routes/account.$accountId.signing.tsx
+++ b/app/routes/account.$accountId.signing.tsx
@@ -1,18 +1,17 @@
-import { LoaderArgs, json } from '@remix-run/node'
+import type { LoaderArgs } from '@remix-run/node'
+import { json } from '@remix-run/node'
 import { useLoaderData, useParams } from '@remix-run/react'
 import { useEffect } from 'react'
 import { Col, Container, Row, Table } from 'react-bootstrap'
 import { FormattedMessage } from 'react-intl'
 import { StrKey } from '../lib/stellar/sdk'
-import { Horizon } from 'stellar-sdk'
+import type { Horizon } from 'stellar-sdk'
 import AccountLink from '~/components/shared/AccountLink'
 import { requestToServer } from '~/lib/stellar/server'
-import {
-  LoadAccountResult,
-  loadAccount,
-} from '~/lib/stellar/server_request_utils'
+import type { LoadAccountResult } from '~/lib/stellar/server_request_utils'
+import { loadAccount } from '~/lib/stellar/server_request_utils'
 import { setTitle } from '~/lib/utils'
-import { AccountRecordSigners } from 'stellar-sdk/lib/types/account'
+import type { AccountRecordSigners } from 'stellar-sdk/lib/types/account'
 
 const Thresholds = ({
   thresholds,

--- a/app/routes/anchor.$id.tsx
+++ b/app/routes/anchor.$id.tsx
@@ -13,8 +13,9 @@ import StellarTomlBadge from '../components/shared/StellarTomlBadge'
 
 import { assetKeyToIssuer, setTitle } from '../lib/utils'
 
-import directory, { DirectoryAnchor } from '../data/directory'
-import { LoaderArgs } from '@remix-run/node'
+import type { DirectoryAnchor } from '../data/directory'
+import directory from '../data/directory'
+import type { LoaderArgs } from '@remix-run/node'
 import { useLoaderData } from '@remix-run/react'
 import { useEffect } from 'react'
 const { anchors } = directory

--- a/app/routes/contract.$contractId.storage.tsx
+++ b/app/routes/contract.$contractId.storage.tsx
@@ -1,9 +1,11 @@
 import { useLoaderData, useParams } from '@remix-run/react'
-import { LoaderArgs, json } from '@remix-run/node'
+import type { LoaderArgs } from '@remix-run/node'
+import { json } from '@remix-run/node'
 import { useEffect } from 'react'
 import Table from 'react-bootstrap/Table'
 
-import { StorageElement, getContractInfo } from '~/lib/stellar/contracts'
+import type { StorageElement } from '~/lib/stellar/contracts'
+import { getContractInfo } from '~/lib/stellar/contracts'
 import { requestToSorobanServer } from '~/lib/stellar/server'
 import { setTitle } from '~/lib/utils'
 import AccountLink from '~/components/shared/AccountLink'

--- a/app/routes/contract.$contractId.tsx
+++ b/app/routes/contract.$contractId.tsx
@@ -1,6 +1,7 @@
 import { Link } from 'react-router-dom'
 import { FormattedMessage, useIntl } from 'react-intl'
-import { LoaderArgs, json } from '@remix-run/node'
+import type { LoaderArgs } from '@remix-run/node'
+import { json } from '@remix-run/node'
 import {
   NavLink,
   Outlet,

--- a/app/routes/effects.$opId.tsx
+++ b/app/routes/effects.$opId.tsx
@@ -7,14 +7,15 @@ import Row from 'react-bootstrap/Row'
 import { FormattedMessage, useIntl } from 'react-intl'
 import { requestToServer } from '~/lib/stellar/server'
 
-import { LoaderArgs, json } from '@remix-run/node'
+import type { LoaderArgs } from '@remix-run/node'
+import { json } from '@remix-run/node'
 import { useLoaderData } from '@remix-run/react'
 
 import EffectTable from '../components/EffectTable'
 import { setTitle } from '../lib/utils'
 
 import { effects } from '~/lib/stellar/server_request_utils'
-import { EffectProps } from '~/components/Effect'
+import type { EffectProps } from '~/components/Effect'
 import { useEffect } from 'react'
 
 export const loader = ({ request, params }: LoaderArgs) => {

--- a/app/routes/effects._index.tsx
+++ b/app/routes/effects._index.tsx
@@ -7,14 +7,15 @@ import Row from 'react-bootstrap/Row'
 import { FormattedMessage, useIntl } from 'react-intl'
 import { requestToServer } from '~/lib/stellar/server'
 
-import { LoaderArgs, json } from '@remix-run/node'
+import type { LoaderArgs } from '@remix-run/node'
+import { json } from '@remix-run/node'
 import { useLoaderData } from '@remix-run/react'
 
 import EffectTable from '../components/EffectTable'
 import { setTitle } from '../lib/utils'
 
 import { effects } from '~/lib/stellar/server_request_utils'
-import { EffectProps } from '~/components/Effect'
+import type { EffectProps } from '~/components/Effect'
 import { useEffect } from 'react'
 
 export const loader = ({ request }: LoaderArgs) => {

--- a/app/routes/lib/account-tab-base.tsx
+++ b/app/routes/lib/account-tab-base.tsx
@@ -1,13 +1,15 @@
-import { LoaderArgs, json } from '@remix-run/node'
+import type { LoaderArgs } from '@remix-run/node'
+import { json } from '@remix-run/node'
 import { useLoaderData, useParams } from '@remix-run/react'
 import { Container, Row } from 'react-bootstrap'
-import { PaymentProps } from '~/components/operations/Payment'
+import type { PaymentProps } from '~/components/operations/Payment'
 import Paging from '~/components/shared/Paging'
 import * as serverRequestUtils from '../../lib/stellar/server_request_utils'
 import { requestToServer } from '~/lib/stellar/server'
-import { FunctionComponent, useEffect } from 'react'
+import type { FunctionComponent } from 'react'
+import { useEffect } from 'react'
 import { setTitle } from '~/lib/utils'
-import { ServerReqFnName } from '~/lib/loader-util'
+import type { ServerReqFnName } from '~/lib/loader-util'
 
 const DEFAULT_RECORD_LIMIT = 30
 

--- a/app/routes/lib/contract-code-tab-base.tsx
+++ b/app/routes/lib/contract-code-tab-base.tsx
@@ -1,7 +1,9 @@
 import { useLoaderData, useParams } from '@remix-run/react'
-import { LoaderArgs, json } from '@remix-run/node'
+import type { LoaderArgs } from '@remix-run/node'
+import { json } from '@remix-run/node'
 import { FormattedMessage } from 'react-intl'
-import { PropsWithChildren, useEffect } from 'react'
+import type { PropsWithChildren } from 'react'
+import { useEffect } from 'react'
 
 import { CodeBlock } from '~/components/shared/CodeBlock'
 import { loadContract } from '~/lib/stellar/contracts'

--- a/app/routes/lib/name-value-table.tsx
+++ b/app/routes/lib/name-value-table.tsx
@@ -1,13 +1,12 @@
-import { LoaderArgs, json } from '@remix-run/node'
+import type { LoaderArgs } from '@remix-run/node'
+import { json } from '@remix-run/node'
 import { useLoaderData, useParams } from '@remix-run/react'
 import { useEffect } from 'react'
 import { Table } from 'react-bootstrap'
 import { FormattedMessage } from 'react-intl'
 import { requestToServer } from '~/lib/stellar/server'
-import {
-  loadAccount,
-  LoadAccountResult,
-} from '~/lib/stellar/server_request_utils'
+import type { LoadAccountResult } from '~/lib/stellar/server_request_utils'
+import { loadAccount } from '~/lib/stellar/server_request_utils'
 import { base64Decode, setTitle } from '~/lib/utils'
 
 const dataValue = (decodeValue: boolean, value?: any): string => {


### PR DESCRIPTION
Feel free to reject the PR if you think it's not necessary.
Then we should remove `@remix-run/eslint-config` from package.json instead.

---

I realized [@remix-run/eslint-config](https://www.npmjs.com/package/@remix-run/eslint-config) is installed but not used.
So I set it up by referring to the page above and run `npm run lint:fix`.
※I'll install `"@testing-library/react"` in another PR, by the way.

I'm not 100% certain using this config is a good practice (considering it's a part of remix package, it seems to be though).

I've never used the `import type { PaymentProps } from './Payment'` style, which the config enforces, but I've seen the syntax here and there in the repo.
In that sense, keeping consistent formatting is good.

---

The following is results of `npm run lint` before and after the change.

before the change:
```
✖ 51 problems (0 errors, 51 warnings)
  0 errors and 1 warning potentially fixable with the `--fix` option.
```

after adding `@remix-run/eslint-config` to `.eslintrc`:
```
✖ 105 problems (4 errors, 101 warnings)
  0 errors and 50 warnings potentially fixable with the `--fix` option.
```

after `npm run lint:fix` was run:
```
✖ 52 problems (0 errors, 52 warnings)
  0 errors and 1 warning potentially fixable with the `--fix` option.
```