### PR TITLE
fix second arg of useEffect

### DIFF
--- a/app/routes/account.$accountId.balances.tsx
+++ b/app/routes/account.$accountId.balances.tsx
@@ -69,7 +69,7 @@ export default function BalancesTab() {
   const { accountId } = useParams()
   useEffect(() => {
     setTitle(`Account Balances ${accountId}`)
-  })
+  }, [accountId])
 
   if (!accountResult) {
     return

--- a/app/routes/account.$accountId.signing.tsx
+++ b/app/routes/account.$accountId.signing.tsx
@@ -88,7 +88,7 @@ export default function BalancesTab() {
   const { accountId } = useParams()
   useEffect(() => {
     setTitle(`Account Signing ${accountId}`)
-  })
+  }, [accountId])
 
   if (!accountResult) {
     return

--- a/app/routes/account.$accountId.tsx
+++ b/app/routes/account.$accountId.tsx
@@ -65,7 +65,7 @@ const AccountSummaryCard = ({
   const { formatMessage } = useIntl()
   useEffect(() => {
     setTitle(`Account ${account.id}`)
-  })
+  }, [account.id])
   return (
     <Card id="account-summary-card">
       <CardHeader>

--- a/app/routes/anchor.$id.tsx
+++ b/app/routes/anchor.$id.tsx
@@ -32,7 +32,7 @@ export default function Anchor() {
   const { formatMessage } = useIntl()
   useEffect(() => {
     setTitle(`Anchor ${name}`)
-  })
+  }, [name])
 
   if (name == null) return null
 

--- a/app/routes/contract.$contractId.interface.tsx
+++ b/app/routes/contract.$contractId.interface.tsx
@@ -43,7 +43,7 @@ export default function InterfaceTab() {
   const { contractId } = useParams()
   useEffect(() => {
     setTitle(`Contract Interface ${contractId}`)
-  }, [])
+  }, [contractId])
 
   const loadResult = useLoaderData<typeof loader>()
 

--- a/app/routes/contract.$contractId.storage.tsx
+++ b/app/routes/contract.$contractId.storage.tsx
@@ -59,7 +59,7 @@ export default function StorageTab() {
   const { contractId } = useParams()
   useEffect(() => {
     setTitle(`Contract Storage ${contractId}`)
-  }, [])
+  }, [contractId])
 
   const loadResult = useLoaderData<typeof loader>() as {
     storage: ReadonlyArray<StorageElement>

--- a/app/routes/effects.$opId.tsx
+++ b/app/routes/effects.$opId.tsx
@@ -39,7 +39,7 @@ export default function Effects() {
   const { formatMessage } = useIntl()
   useEffect(() => {
     setTitle(formatMessage({ id: 'effects' }))
-  })
+  }, [formatMessage])
 
   return (
     <Container>

--- a/app/routes/effects._index.tsx
+++ b/app/routes/effects._index.tsx
@@ -39,7 +39,7 @@ export default function Effects() {
   const { formatMessage } = useIntl()
   useEffect(() => {
     setTitle(formatMessage({ id: 'effects' }))
-  })
+  }, [formatMessage])
 
   return (
     <Container>

--- a/app/routes/ledger.$ledgerId.tsx
+++ b/app/routes/ledger.$ledgerId.tsx
@@ -114,7 +114,7 @@ export default function Ledger() {
   const { formatMessage } = useIntl()
   useEffect(() => {
     setTitle(`${formatMessage({ id: 'ledger' })} ${sequence}`)
-  })
+  }, [formatMessage, sequence])
 
   if (!id) return null
 

--- a/app/routes/ledgers._index.tsx
+++ b/app/routes/ledgers._index.tsx
@@ -27,7 +27,7 @@ export default function Ledgers() {
   const { formatMessage } = useIntl()
   useEffect(() => {
     setTitle(formatMessage({ id: 'ledgers' }))
-  })
+  }, [formatMessage])
 
   return (
     <Container>

--- a/app/routes/lib/account-tab-base.tsx
+++ b/app/routes/lib/account-tab-base.tsx
@@ -60,7 +60,7 @@ const accountTabComponent = function <loaderFnType>(
     const { accountId } = useParams()
     useEffect(() => {
       setTitle(`Account ${name} ${accountId}`)
-    })
+    }, [accountId])
 
     if (!records || records.length === 0) {
       return <div style={{ marginTop: 20, marginBottom: 20 }}>No Records</div>

--- a/app/routes/lib/contract-code-tab-base.tsx
+++ b/app/routes/lib/contract-code-tab-base.tsx
@@ -48,7 +48,7 @@ export default function contractCodeTab(loader: Function, language?: string) {
     const { contractId } = useParams()
     useEffect(() => {
       setTitle(`Contract Code ${contractId}`)
-    })
+    }, [contractId])
 
     const codeProps = useLoaderData<typeof loader>() as CodeProps | null
 

--- a/app/routes/lib/name-value-table.tsx
+++ b/app/routes/lib/name-value-table.tsx
@@ -68,7 +68,7 @@ const nameValueAccountTab = function (name: string) {
     const { accountId } = useParams()
     useEffect(() => {
       setTitle(`Account ${name} ${accountId}`)
-    })
+    }, [accountId])
 
     if (!accountResult) {
       return

--- a/app/routes/operations._index.tsx
+++ b/app/routes/operations._index.tsx
@@ -26,7 +26,7 @@ export default function Operations() {
   const { formatMessage } = useIntl()
   useEffect(() => {
     setTitle(formatMessage({ id: 'operations' }))
-  })
+  }, [formatMessage])
 
   return (
     <Container>

--- a/app/routes/payments._index.tsx
+++ b/app/routes/payments._index.tsx
@@ -25,7 +25,7 @@ export default function Payments() {
   const { formatMessage } = useIntl()
   useEffect(() => {
     setTitle(formatMessage({ id: 'payments' }))
-  })
+  }, [formatMessage])
 
   return (
     <Container>

--- a/app/routes/trades._index.tsx
+++ b/app/routes/trades._index.tsx
@@ -27,7 +27,7 @@ export default function Trades() {
   const { formatMessage } = useIntl()
   useEffect(() => {
     setTitle(formatMessage({ id: 'trades' }))
-  })
+  }, [formatMessage])
 
   return (
     <Container>

--- a/app/routes/tx.$txHash.tsx
+++ b/app/routes/tx.$txHash.tsx
@@ -87,7 +87,7 @@ export default function Transaction() {
   const { formatMessage } = useIntl()
   useEffect(() => {
     setTitle(`${formatMessage({ id: 'transaction' })} ${id}`)
-  })
+  }, [formatMessage, id])
 
   if (!id) return null
 


### PR DESCRIPTION
# PR to fix this issue: 

https://github.com/chatch/stellarexplorer/issues/577

# Problem (and fix):

The second argument of `useEffect` was not correctly defined.
So the code in `useEffect` was executed on every rendering.
The variables including the functions used in `useEffect` should be defined in the second argument.
Then the code in `useEffect` is executed on the first rendering and when the variables are changed, which is the correct behavior.

# How the title looks like with this change (for example):

<img width="508" alt="スクリーンショット 2024-01-04 15 16 27" src="https://github.com/chatch/stellarexplorer/assets/1908717/da4d494f-ca80-488f-92ba-769b1296acfd">
