### PR TITLE
Revert smoke test

### DIFF
--- a/e2e/production.spec.ts
+++ b/e2e/production.spec.ts
@@ -3,17 +3,18 @@ import { clickLinkAndVerify, getFirstLink, verifyOpeningNewPage } from './utils'
 
 const baseUrl = 'https://steexp.com'
 
-const expectedAccountPageTitle =
-  // 'Stellar Explorer | Account Balances'
-  'Stellar Explorer | Account'
-
 test('top page', async ({ page }) => {
   await page.goto(`${baseUrl}/`)
   await expect(page).toHaveTitle('Stellar Explorer | Home')
 
   // Click account link
   const accountLink = await getFirstLink(page, 0)
-  await clickLinkAndVerify(baseUrl, page, accountLink, expectedAccountPageTitle)
+  await clickLinkAndVerify(
+    baseUrl,
+    page,
+    accountLink,
+    'Stellar Explorer | Account Balances',
+  )
 })
 
 test('operations', async ({ page }) => {
@@ -24,7 +25,12 @@ test('operations', async ({ page }) => {
 
   // Click account link
   const accountLink = await getFirstLink(page, 0)
-  await clickLinkAndVerify(baseUrl, page, accountLink, expectedAccountPageTitle)
+  await clickLinkAndVerify(
+    baseUrl,
+    page,
+    accountLink,
+    'Stellar Explorer | Account Balances',
+  )
 
   // Click transaction link
   await page.goto(targetUrl)
@@ -55,7 +61,12 @@ test('transactions', async ({ page }) => {
   // Click account link
   await page.goto(targetUrl)
   const accountLink = await getFirstLink(page, 1)
-  await clickLinkAndVerify(baseUrl, page, accountLink, expectedAccountPageTitle)
+  await clickLinkAndVerify(
+    baseUrl,
+    page,
+    accountLink,
+    'Stellar Explorer | Account Balances',
+  )
 
   // Click ledger link
   await page.goto(targetUrl)
@@ -130,7 +141,12 @@ test('effects', async ({ page }) => {
 
   // Click account link
   const accountLink = await getFirstLink(page, 0)
-  await clickLinkAndVerify(baseUrl, page, accountLink, expectedAccountPageTitle)
+  await clickLinkAndVerify(
+    baseUrl,
+    page,
+    accountLink,
+    'Stellar Explorer | Account Balances',
+  )
 })
 
 test('payments', async ({ page }) => {
@@ -141,7 +157,12 @@ test('payments', async ({ page }) => {
 
   // Click account link
   const accountLink = await getFirstLink(page, 0)
-  await clickLinkAndVerify(baseUrl, page, accountLink, expectedAccountPageTitle)
+  await clickLinkAndVerify(
+    baseUrl,
+    page,
+    accountLink,
+    'Stellar Explorer | Account Balances',
+  )
 
   // Click transaction link
   await page.goto(targetUrl)
@@ -166,7 +187,7 @@ test('trades', async ({ page }) => {
     baseUrl,
     page,
     account1Link,
-    expectedAccountPageTitle,
+    'Stellar Explorer | Account Balances',
   )
 
   // Click account 2 link
@@ -176,7 +197,7 @@ test('trades', async ({ page }) => {
     baseUrl,
     page,
     account2Link,
-    expectedAccountPageTitle,
+    'Stellar Explorer | Account Balances',
   )
 })
 


### PR DESCRIPTION
The smoke test passed with `const baseUrl = 'http://publicnet.local:3000'` locallly. 


```shell
$ grep 'const baseUrl' e2e/production.spec.ts
const baseUrl = 'http://publicnet.local:3000'

$ npm run test:e2e

> stellarexplorer@2.4.0 test:e2e
> playwright test


Running 11 tests using 4 workers
  11 passed (20.8s)

To open last HTML report run:

  npx playwright show-report
```

---

# The following is old information

Ran smoke test against http://testnet.local:3000 locally and there were two errors.
Because the accounts were not found on the testnet network.
I think this can't happen on the production env, so I think we're ready to go.

<img width="1262" alt="スクリーンショット 2024-01-05 17 42 01" src="https://github.com/chatch/stellarexplorer/assets/1908717/d5963181-3c7c-4aac-b688-8e46cdd59895">
