### PR TITLE
fix pagination link

### DIFF
--- a/app/components/shared/PagingControls.tsx
+++ b/app/components/shared/PagingControls.tsx
@@ -12,14 +12,17 @@ const PagingControls = ({
   handleClickPrev,
   hidePrev,
 }: PagingControlsProps) => (
-  <div id="paging-controls">
+  <div
+    id="paging-controls"
+    className={`${hidePrev ? 'paging-buttons-right' : 'paging-buttons'}`}
+  >
     {!hidePrev && (
       <button onClick={handleClickPrev}>
         &larr; <FormattedMessage id="paging.prev" />
       </button>
     )}
 
-    <button onClick={handleClickNext} style={{ float: 'right' }}>
+    <button onClick={handleClickNext}>
       <FormattedMessage id="paging.next" /> &rarr;
     </button>
   </div>

--- a/app/styles/styles.css
+++ b/app/styles/styles.css
@@ -615,6 +615,17 @@ button[id^="btn-custom-network"]:first-of-type {
   background-color: #3c4452 !important;
 }
 
+.paging-buttons {
+  display: flex;
+  justify-content: space-between;
+
+}
+
+.paging-buttons-right {
+  display: flex;
+  justify-content: flex-end;
+}
+
 a {
   color: #00c292;
 }


### PR DESCRIPTION
On the first page, the pagination link is attached to the table.
On the second and subsequent pages, it's floating.
The fixed version follows the second pattern above on each page.

![スクリーンショット 2024-01-25 14 46 39](https://github.com/chatch/stellarexplorer/assets/1908717/4d0f25f6-a9b6-404e-8fbe-729b86febbfd)

![スクリーンショット 2024-01-25 14 51 24](https://github.com/chatch/stellarexplorer/assets/1908717/2b2de968-18fa-49bc-9a5f-607135420e29)
