### PR TITLE
API: add access log

### DIFF
--- a/api/__tests__/access-log.test.js
+++ b/api/__tests__/access-log.test.js
@@ -1,0 +1,75 @@
+// Verifies that the morgan access-log middleware emits exactly one log line
+// per finished request, with the format documented in api/index.js. Skips
+// /health (currently no such route; the skip is preemptive for a future
+// Fly health probe).
+const request = require('supertest')
+const app = require('../index.js')
+const { trivialWasm } = require('./helpers/paths')
+
+describe('access log', () => {
+  let stdoutSpy
+  let lines
+
+  beforeEach(() => {
+    lines = []
+    // morgan writes via console-log → process.stdout.write. Capture chunks
+    // and split on newlines so we can inspect individual lines.
+    stdoutSpy = jest
+      .spyOn(process.stdout, 'write')
+      .mockImplementation((chunk) => {
+        const text = typeof chunk === 'string' ? chunk : chunk.toString()
+        for (const piece of text.split('\n')) {
+          if (piece) lines.push(piece)
+        }
+        return true
+      })
+  })
+
+  afterEach(() => {
+    stdoutSpy.mockRestore()
+  })
+
+  // ISO timestamp, METHOD, URL, STATUS, "resLen/reqLen", "-", "<n> ms",
+  // "<ua>", "<referer>"
+  const LINE_RE =
+    /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z (GET|POST) \/[\w/-]+ \d{3} (-|\d+)(\/(-|\d+))? - \d+(?:\.\d+)? ms "[^"]*" "[^"]*"$/
+
+  it('emits exactly one log line for a successful /wat request', async () => {
+    const before = lines.length
+    await request(app)
+      .post('/wat')
+      .set('User-Agent', 'steexp-access-log-test')
+      .set('Referer', 'https://steexp.com/contract/CABC')
+      .attach('contract', trivialWasm)
+      .expect(200)
+
+    const newLines = lines.slice(before).filter((l) =>
+      LINE_RE.test(l),
+    )
+    expect(newLines).toHaveLength(1)
+    expect(newLines[0]).toContain('POST /wat 200')
+    expect(newLines[0]).toContain('"steexp-access-log-test"')
+    expect(newLines[0]).toContain('"https://steexp.com/contract/CABC"')
+  })
+
+  it('emits one log line even when the request fails', async () => {
+    const before = lines.length
+    // Missing file → 400 from the route handler, but morgan still logs.
+    await request(app).post('/wat').expect(400)
+
+    const newLines = lines.slice(before).filter((l) => LINE_RE.test(l))
+    expect(newLines).toHaveLength(1)
+    expect(newLines[0]).toContain('POST /wat 400')
+  })
+
+  it('does not log /health requests', async () => {
+    // No /health route exists yet, but a 404 still flows through morgan
+    // unless the skip predicate matches. This test pins that contract so
+    // a future Fly health probe stays out of the log.
+    const before = lines.length
+    await request(app).get('/health').expect(404)
+
+    const newLines = lines.slice(before).filter((l) => LINE_RE.test(l))
+    expect(newLines).toHaveLength(0)
+  })
+})

--- a/api/index.js
+++ b/api/index.js
@@ -12,6 +12,7 @@ Sentry.init({
 const express = require('express')
 const { rateLimit } = require('express-rate-limit')
 const multer = require('multer')
+const morgan = require('morgan')
 const { execFile, execFileSync } = require('child_process')
 const crypto = require('crypto')
 const fs = require('fs')
@@ -120,6 +121,26 @@ const corsOptions = {
 app.use(cors(corsOptions))
 
 app.set('trust proxy', 2)
+
+// One-line access log per finished request. Goes to stdout (Fly captures it
+// into `fly logs`). Skips /health so any future Fly health probe doesn't
+// drown the log. Includes request + response Content-Length so a single
+// grep shows both the upload size and the response size.
+app.use(morgan((tokens, req, res) => {
+  const reqLen = req.headers['content-length'] || '-'
+  const resLen = res.getHeader('content-length') || '-'
+  return [
+    new Date().toISOString(),
+    tokens.method(req, res),
+    tokens.url(req, res),
+    tokens.status(req, res),
+    `${resLen}/${reqLen}`,
+    '-',
+    `${tokens['response-time'](req, res)} ms`,
+    `"${tokens['user-agent'](req, res) || '-'}"`,
+    `"${tokens.referrer(req, res) || '-'}"`,
+  ].join(' ')
+}, { skip: (req) => req.path === '/health' }))
 
 /**
  * Decompile a wasm file using the wabt wasm-decompile tool

--- a/api/package.json
+++ b/api/package.json
@@ -1,7 +1,7 @@
 {
   "name": "stellarexplorer-backend-api",
   "description": "Backend api for supporting stellarexplorer",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "license": "Apache-2.0",
   "author": "Chris Hatch <hatch@tuta.io>",
   "homepage": "https://steexp.com",
@@ -27,6 +27,7 @@
     "cors": "^2.8.6",
     "express": "5.2.1",
     "express-rate-limit": "^8.5.2",
+    "morgan": "^1.11.0",
     "multer": "2.2.0"
   }
 }

--- a/api/pnpm-lock.yaml
+++ b/api/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       express-rate-limit:
         specifier: ^8.5.2
         version: 8.5.2(express@5.2.1)
+      morgan:
+        specifier: ^1.11.0
+        version: 1.11.0
       multer:
         specifier: 2.2.0
         version: 2.2.0
@@ -688,6 +691,10 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
+  basic-auth@2.0.1:
+    resolution: {integrity: sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==}
+    engines: {node: '>= 0.8'}
+
   body-parser@2.3.0:
     resolution: {integrity: sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==}
     engines: {node: '>=18'}
@@ -820,6 +827,14 @@ packages:
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
+
+  debug@2.6.9:
+    resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
 
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
@@ -1388,6 +1403,13 @@ packages:
   module-details-from-path@1.0.4:
     resolution: {integrity: sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==}
 
+  morgan@1.11.0:
+    resolution: {integrity: sha512-zSkVu3t18r39pw4ixfBKvfZi3y2UOqr7d4WYwcj3m8nXpEQK4rPO6GLzs/CExoRgmX3y9EjmmcXqv6jq0SK46g==}
+    engines: {node: '>= 0.8.0'}
+
+  ms@2.0.0:
+    resolution: {integrity: sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==}
+
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
@@ -1432,6 +1454,10 @@ packages:
 
   on-finished@2.4.1:
     resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
+    engines: {node: '>= 0.8'}
+
+  on-headers@1.1.0:
+    resolution: {integrity: sha512-737ZY3yNnXy37FHkQxPzt4UZ2UWPWiCZWLvFZ4fu5cueciegX0zGPnrlY6bwRg4FdQOe9YU8MkmJwGhoMybl8A==}
     engines: {node: '>= 0.8'}
 
   once@1.4.0:
@@ -1558,6 +1584,9 @@ packages:
   router@2.2.0:
     resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
     engines: {node: '>= 18'}
+
+  safe-buffer@5.1.2:
+    resolution: {integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==}
 
   safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
@@ -2588,6 +2617,10 @@ snapshots:
 
   baseline-browser-mapping@2.10.42: {}
 
+  basic-auth@2.0.1:
+    dependencies:
+      safe-buffer: 5.1.2
+
   body-parser@2.3.0:
     dependencies:
       bytes: 3.1.2
@@ -2715,6 +2748,10 @@ snapshots:
       path-key: 3.1.1
       shebang-command: 2.0.0
       which: 2.0.2
+
+  debug@2.6.9:
+    dependencies:
+      ms: 2.0.0
 
   debug@4.4.3:
     dependencies:
@@ -3448,6 +3485,18 @@ snapshots:
 
   module-details-from-path@1.0.4: {}
 
+  morgan@1.11.0:
+    dependencies:
+      basic-auth: 2.0.1
+      debug: 2.6.9
+      depd: 2.0.0
+      on-finished: 2.4.1
+      on-headers: 1.1.0
+    transitivePeerDependencies:
+      - supports-color
+
+  ms@2.0.0: {}
+
   ms@2.1.3: {}
 
   multer@2.2.0:
@@ -3480,6 +3529,8 @@ snapshots:
   on-finished@2.4.1:
     dependencies:
       ee-first: 1.1.1
+
+  on-headers@1.1.0: {}
 
   once@1.4.0:
     dependencies:
@@ -3601,6 +3652,8 @@ snapshots:
       path-to-regexp: 8.4.2
     transitivePeerDependencies:
       - supports-color
+
+  safe-buffer@5.1.2: {}
 
   safe-buffer@5.2.1: {}
 


### PR DESCRIPTION
Add one-line-per-request access logging via morgan, emitting to stdout (Fly captures into `fly logs`).

Format:
```
2026-07-06T03:14:15Z POST /decompile 200 18432/51200 - 41.2 ms "curl/8.5.0" "https://steexp.com/contract/CABC…"
```

ISO timestamp, method, URL, status, response-bytes/request-bytes, response time, user-agent, and referer. `/health` is skipped so a future Fly health probe won't drown the log.

Why now: Sentry is configured with `tracesSampleRate: 0` (errors only), so successful calls are invisible there. Useful for low-volume usage stats.

Includes three integration tests pinning the format, error-path logging, and the /health skip.