### PR TITLE
Log contract ID with API access log entries

### DIFF
--- a/api/__tests__/access-log.test.js
+++ b/api/__tests__/access-log.test.js
@@ -30,9 +30,9 @@ describe('access log', () => {
   })
 
   // ISO timestamp, METHOD, URL, STATUS, "resLen/reqLen", "-", "<n> ms",
-  // "<ua>", "<referer>"
+  // contract-id (or "-"), "<ua>", "<referer>"
   const LINE_RE =
-    /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z (GET|POST) \/[\w/-]+ \d{3} (-|\d+)(\/(-|\d+))? - \d+(?:\.\d+)? ms "[^"]*" "[^"]*"$/
+    /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z (GET|POST) \/[\w/-]+ \d{3} (-|\d+)(\/(-|\d+))? - \d+(?:\.\d+)? ms (?:-|\S+) "[^"]*" "[^"]*"$/
 
   it('emits exactly one log line for a successful /wat request', async () => {
     const before = lines.length
@@ -71,5 +71,56 @@ describe('access log', () => {
 
     const newLines = lines.slice(before).filter((l) => LINE_RE.test(l))
     expect(newLines).toHaveLength(0)
+  })
+
+  it('logs the X-Steexp-Contract-Id header when set', async () => {
+    const before = lines.length
+    await request(app)
+      .post('/wat')
+      .set('X-Steexp-Contract-Id', 'CDL74RF5BLYR2YBLCCI7F5FB6TPSCLKEJUBSD2RSVWZ4YHF3VMFAIGWA')
+      .attach('contract', trivialWasm)
+      .expect(200)
+
+    const newLines = lines.slice(before).filter((l) => LINE_RE.test(l))
+    expect(newLines).toHaveLength(1)
+    expect(newLines[0]).toContain(
+      'CDL74RF5BLYR2YBLCCI7F5FB6TPSCLKEJUBSD2RSVWZ4YHF3VMFAIGWA',
+    )
+  })
+
+  it('caps the contract ID at 100 characters', async () => {
+    // Node's http module rejects header values with control characters,
+    // so we can only test the length cap here. Control-char stripping is
+    // a one-line regex and doesn't need a runtime test.
+    const longId = 'C' + 'A'.repeat(150)
+    const before = lines.length
+    await request(app)
+      .post('/wat')
+      .set('X-Steexp-Contract-Id', longId)
+      .attach('contract', trivialWasm)
+      .expect(200)
+
+    const newLines = lines.slice(before).filter((l) => LINE_RE.test(l))
+    expect(newLines).toHaveLength(1)
+    const fields = newLines[0].split(' ')
+    // contract-id slot is field 8 (after timestamp, METHOD, URL, STATUS,
+    // "resLen/reqLen", "-", "<n> ms")
+    expect(fields[8]).toBe('C' + 'A'.repeat(99))
+    expect(fields[8]).toHaveLength(100)
+  })
+
+  it('emits a dash when X-Steexp-Contract-Id is not set', async () => {
+    const before = lines.length
+    await request(app)
+      .post('/wat')
+      .attach('contract', trivialWasm)
+      .expect(200)
+
+    const newLines = lines.slice(before).filter((l) => LINE_RE.test(l))
+    expect(newLines).toHaveLength(1)
+    // contract-id slot is field 8 (after timestamp, METHOD, URL, STATUS,
+    // "resLen/reqLen", "-", "<n> ms")
+    const fields = newLines[0].split(' ')
+    expect(fields[8]).toBe('-')
   })
 })

--- a/api/index.js
+++ b/api/index.js
@@ -126,6 +126,14 @@ app.set('trust proxy', 2)
 // into `fly logs`). Skips /health so any future Fly health probe doesn't
 // drown the log. Includes request + response Content-Length so a single
 // grep shows both the upload size and the response size.
+// The contract-id token is sanitised: control characters are stripped and
+// the value is capped at 100 chars, since the header value flows into a
+// log line that downstream tooling (Fly log viewer, grep pipelines) reads.
+morgan.token('contract-id', (req) => {
+  const raw = req.headers['x-steexp-contract-id']
+  if (!raw) return '-'
+  return String(raw).replace(/[\x00-\x1f\x7f]/g, '').slice(0, 100)
+})
 app.use(morgan((tokens, req, res) => {
   const reqLen = req.headers['content-length'] || '-'
   const resLen = res.getHeader('content-length') || '-'
@@ -137,6 +145,7 @@ app.use(morgan((tokens, req, res) => {
     `${resLen}/${reqLen}`,
     '-',
     `${tokens['response-time'](req, res)} ms`,
+    tokens['contract-id'](req, res),
     `"${tokens['user-agent'](req, res) || '-'}"`,
     `"${tokens.referrer(req, res) || '-'}"`,
   ].join(' ')

--- a/api/package.json
+++ b/api/package.json
@@ -1,7 +1,7 @@
 {
   "name": "stellarexplorer-backend-api",
   "description": "Backend api for supporting stellarexplorer",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "license": "Apache-2.0",
   "author": "Chris Hatch <hatch@tuta.io>",
   "homepage": "https://steexp.com",

--- a/app/lib/stellar/contracts.ts
+++ b/app/lib/stellar/contracts.ts
@@ -149,15 +149,19 @@ const loadContract = async (
   }
 }
 
+// Send the contract ID as X-Steexp-Contract-Id so the API can log it.
+// Browser default referrer-policy strips the path on cross-origin fetches,
+// so the Referer alone won't tell us which contract page initiated the call.
 const postWasmToWabtBackendRoute =
   (path: string) =>
-  (wasmHexString: string): Promise<string> => {
+  (contractId: string, wasmHexString: string): Promise<string> => {
     const wasmBytes = hexStringToBytes(wasmHexString)
     const blob = new Blob([new Uint8Array(wasmBytes)])
     const formData = new FormData()
     formData.append('contract', blob)
     return fetch(`${API_URL}${path}`, {
       method: 'POST',
+      headers: { 'X-Steexp-Contract-Id': contractId },
       body: formData,
     }).then((response) => response.text())
   }
@@ -166,6 +170,7 @@ const getContractDecompiled = postWasmToWabtBackendRoute('/decompile')
 const getContractWat = postWasmToWabtBackendRoute('/wat')
 
 const getContractInterface = (
+  contractId: string,
   wasmHexString: string,
 ): Promise<Record<string, string>> => {
   const wasmBytes = hexStringToBytes(wasmHexString)
@@ -174,6 +179,7 @@ const getContractInterface = (
   formData.append('contract', blob)
   return fetch(`${API_URL}/interface`, {
     method: 'POST',
+    headers: { 'X-Steexp-Contract-Id': contractId },
     body: formData,
   }).then((response) => response.json())
 }

--- a/app/routes/contract.$contractId.interface.tsx
+++ b/app/routes/contract.$contractId.interface.tsx
@@ -29,12 +29,13 @@ const Interface = ({
 
 export const clientLoader = async ({ params, request }: LoaderFunctionArgs) => {
   const server = await requestToSorobanServer(request)
-  return loadContract(server, params.contractId as string)
+  const contractId = params.contractId as string
+  return loadContract(server, contractId)
     .then((result: any) => {
       if (!result) {
         return null
       }
-      return getContractInterface(result.wasmCode)
+      return getContractInterface(contractId, result.wasmCode)
     })
     .then(json)
 }

--- a/app/routes/lib/contract-code-tab-base.tsx
+++ b/app/routes/lib/contract-code-tab-base.tsx
@@ -29,18 +29,17 @@ export const contractCodeLoaderFn =
   (getCodeFn: Function) =>
   async ({ params, request }: LoaderFunctionArgs) => {
     const server = await requestToSorobanServer(request)
-    return loadContract(server, params.contractId as string).then(
-      async (result: any) => {
-        if (!result) {
-          return null
-        }
+    const contractId = params.contractId as string
+    return loadContract(server, contractId).then(async (result: any) => {
+      if (!result) {
+        return null
+      }
 
-        const { wasmCode, wasmCodeLedger } = result
-        const decompiledCode = await getCodeFn(wasmCode)
+      const { wasmCode, wasmCodeLedger } = result
+      const decompiledCode = await getCodeFn(contractId, wasmCode)
 
-        return json({ wasmCode, wasmCodeLedger, decompiledCode })
-      },
-    )
+      return json({ wasmCode, wasmCodeLedger, decompiledCode })
+    })
   }
 
 export default function contractCodeTab(loader: Function, language?: string) {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "stellarexplorer",
   "description": "Ledger explorer for the Stellar network",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "type": "module",
   "license": "Apache-2.0",
   "author": "Chris Hatch <devcebfaff@proton.me>",


### PR DESCRIPTION
Currently the API access log only sees `Referer: https://steexp.com/` because the browser default `strict-origin-when-cross-origin` strips the path on cross-origin fetches. So we know *someone* hit /decompile, but not which contract page drove them there.

This PR fixes that by having the web app pass the contract ID it's already loading as `X-Steexp-Contract-Id` on every API call. The API logs it as a new field in the access log line, sanitised (control chars stripped, capped at 100 chars).

Before:
```
2026-07-06T04:25:11Z POST /decompile 200 61194/19716 - 78.3 ms "Mozilla/5.0…" "https://steexp.com/"
```

After:
```
2026-07-06T04:25:11Z POST /decompile 200 61194/19716 - 78.3 ms CDL74RF5BLYR… "Mozilla/5.0…" "https://steexp.com/"
```

Web app: `postWasmToWabtBackendRoute` and `getContractInterface` now take `(contractId, wasmHex)`. Call sites updated.

Bumps web app 3.1.1 → 3.1.2 and API 1.0.7 → 1.0.8.