### PR TITLE
Add decentralized static build target

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,86 @@ pnpm test:e2e:report
 pnpm i && pnpm build
 ```
 
+`pnpm build` is the centralized Cloudflare Pages build. It keeps the app
+root-based for <https://steexp.com> and the existing Pages SPA fallback.
+
+`pnpm build:decentralized` sets `STEEXP_BUILD_TARGET=decentralized` and emits a
+static SPA build with relative Vite asset URLs. This target is intended for
+IPFS DNSLink/subdomain gateways, ArNS/custom Arweave entrypoints, or any
+gateway/domain that serves the app at path root. Direct refreshes on nested
+routes still require the gateway to serve `index.html` as the SPA fallback. Raw
+path gateways such as `/ipfs/<cid>/...` or `/arweave-id/...` are not supported
+by this target.
+
+### Deploy to IPFS
+
+The decentralized build should be served from a gateway origin root. Use an IPFS
+subdomain gateway or DNSLink/custom domain, not a path gateway URL such as
+`https://ipfs.io/ipfs/<cid>/...`.
+
+```sh
+pnpm build:decentralized
+ipfs add -r --cid-version=1 --pin=true build/client
+```
+
+The last CID printed for `build/client` is the site root CID. Verify it with a
+subdomain gateway:
+
+```sh
+CID=<site-root-cid>
+open "https://${CID}.ipfs.dweb.link/"
+```
+
+For a custom domain, publish a DNSLink TXT record:
+
+```txt
+_dnslink.example.com.  TXT  "dnslink=/ipfs/<site-root-cid>"
+```
+
+Then point the domain at an IPFS gateway that supports DNSLink. The app expects
+the gateway to serve `index.html` for deep links such as `/operations`; if the
+gateway does not provide SPA fallback, users should enter through `/`.
+
+If you use a pinning service instead of your own Kubo node, upload the whole
+`build/client` directory and pin the returned directory CID. The same DNSLink
+and SPA fallback notes apply.
+
+### Deploy to Arweave
+
+The Arweave target is also root-oriented. Use an ArNS name or custom Arweave
+gateway entrypoint that serves the uploaded manifest at `/`. A raw manifest
+transaction URL such as `https://arweave.net/<manifest-tx-id>/...` is useful for
+inspection, but it is not the intended production URL for this app.
+
+Turbo can upload the folder and create an Arweave path manifest:
+
+```sh
+pnpm build:decentralized
+pnpm add -g @ardrive/turbo-sdk
+turbo upload-folder \
+  --folder-path build/client \
+  --index-file index.html \
+  --fallback-file index.html \
+  --token arweave \
+  --wallet-file /path/to/arweave-wallet.json
+```
+
+Save the returned manifest transaction id. The `--fallback-file index.html`
+setting is important for SPA route refreshes when the gateway honors manifest
+fallbacks.
+
+After upload, point your ArNS name or custom Arweave gateway routing at the
+manifest transaction id. Verify the production URL is root-style, for example:
+
+```txt
+https://your-name.arweave.net/
+https://your-domain.example/
+```
+
+Do not publish a decentralized release that only works at
+`https://arweave.net/<manifest-tx-id>/`; that path-style gateway shape is out of
+scope for this build target.
+
 ## Languages
 
 Use the language selector in the top right corner to change the language.

--- a/app/SearchBox.tsx
+++ b/app/SearchBox.tsx
@@ -6,9 +6,26 @@ import { searchStrToPath } from './lib/search'
 import { isSecretKey } from './lib/stellar/utils'
 import { useState } from 'react'
 import { useLocation, useNavigate } from '@remix-run/react'
+import { publicAssetUrl } from './lib/build-target'
 
-const searchSvg = '/search.svg'
-const infoCircleSvg = '/info-circle.svg'
+const searchSvg = publicAssetUrl('search.svg')
+const infoCircleSvg = publicAssetUrl('info-circle.svg')
+const searchStellarAddressImg = publicAssetUrl(
+  'search/search_stellar_address.png',
+)
+const searchAccountPublicImg = publicAssetUrl(
+  'search/search_account_public.png',
+)
+const searchTxHashImg = publicAssetUrl('search/search_tx_hash.png')
+const searchContractImg = publicAssetUrl('search/search_contract.png')
+const searchLedgerImg = publicAssetUrl('search/search_ledger.png')
+const searchAnchorNameFullImg = publicAssetUrl(
+  'search/search_anchor_name_full.png',
+)
+const searchAnchorNamePartialImg = publicAssetUrl(
+  'search/search_anchor_name_partial.png',
+)
+const searchAssetImg = publicAssetUrl('search/search_asset.png')
 import { isPathClaimableBalance } from './lib/utilities'
 
 const HelpModal = ({
@@ -34,10 +51,7 @@ const HelpModal = ({
           >
             Stellar federated address
           </a>
-          <img
-            src="/search/search_stellar_address.png"
-            alt="search by ledger"
-          />
+          <img src={searchStellarAddressImg} alt="search by ledger" />
         </div>
       </div>
       <div>
@@ -45,7 +59,7 @@ const HelpModal = ({
         <div className="search-desc">
           Also called a Public Key or Public Address
           <img
-            src="/search/search_account_public.png"
+            src={searchAccountPublicImg}
             alt="search by public account address"
             width="100%"
           />
@@ -54,7 +68,7 @@ const HelpModal = ({
       <div>
         <div className="search-sub-heading">Transaction Hash</div>
         <img
-          src="/search/search_tx_hash.png"
+          src={searchTxHashImg}
           alt="search by transaction hash"
           width="100%"
         />
@@ -62,14 +76,14 @@ const HelpModal = ({
       <div>
         <div className="search-sub-heading">Contract Address or Hash</div>
         <img
-          src="/search/search_contract.png"
+          src={searchContractImg}
           alt="search by contract address"
           width="100%"
         />
       </div>
       <div>
         <div className="search-sub-heading">Ledger</div>
-        <img src="/search/search_ledger.png" alt="search by ledger" />
+        <img src={searchLedgerImg} alt="search by ledger" />
       </div>
       <div className="search-sub-heading">Anchor Name</div>
       <div>
@@ -88,7 +102,7 @@ const HelpModal = ({
           <div className="search-desc">
             <div>Full name:</div>
             <img
-              src="/search/search_anchor_name_full.png"
+              src={searchAnchorNameFullImg}
               alt="search by anchor full name"
             />
           </div>
@@ -96,7 +110,7 @@ const HelpModal = ({
           <div className="search-desc">
             <div>Partial name:</div>
             <img
-              src="/search/search_anchor_name_partial.png"
+              src={searchAnchorNamePartialImg}
               alt="search by anchor partial name"
             />
           </div>
@@ -104,7 +118,7 @@ const HelpModal = ({
       </div>
       <div>
         <div className="search-sub-heading">Asset Code</div>
-        <img src="/search/search_asset.png" alt="search by asset code" />
+        <img src={searchAssetImg} alt="search by asset code" />
       </div>
       <hr />
       <h4>OpenSearch:</h4>

--- a/app/components/LiquidityPoolTable.tsx
+++ b/app/components/LiquidityPoolTable.tsx
@@ -8,6 +8,7 @@ import { formatAmountToHumanReadable, getAssetCode } from '~/lib/utilities'
 
 import styles from './LiquidityPoolTable.module.css'
 import type { HorizonApi } from '@stellar/stellar-sdk/lib/esm/horizon/horizon_api.js'
+import { publicAssetUrl } from '~/lib/build-target'
 
 interface ParentProps {
   compact: boolean
@@ -20,7 +21,7 @@ interface LiquidityPoolTableProps {
   records: ReadonlyArray<LiquidityPoolProps>
 }
 
-const fallBackAssetIcon = '/img/circle.svg'
+const fallBackAssetIcon = publicAssetUrl('img/circle.svg')
 
 export const PoolAsset = ({
   reserves,

--- a/app/components/layout/Footer.tsx
+++ b/app/components/layout/Footer.tsx
@@ -1,8 +1,9 @@
 import { Col, Container, Row } from 'react-bootstrap'
+import { publicAssetUrl } from '~/lib/build-target'
 
-const ghImg = '/img/gh.svg'
-const supportImg = '/img/support.svg'
-const stellarIconImg = '/stellar.ico'
+const ghImg = publicAssetUrl('img/gh.svg')
+const supportImg = publicAssetUrl('img/support.svg')
+const stellarIconImg = publicAssetUrl('stellar.ico')
 
 export default function Footer() {
   return (

--- a/app/components/layout/NetworkSelector.tsx
+++ b/app/components/layout/NetworkSelector.tsx
@@ -2,6 +2,7 @@ import { networks } from '~/lib/stellar'
 import type { NetworkDetails } from '~/lib/stellar/networks'
 import CustomNetworkButton from '../shared/CustomNetworkButton'
 import Cookies from 'js-cookie'
+import { isDecentralizedBuild } from '~/lib/build-target'
 
 const HOME_PUBLIC = 'https://steexp.com'
 const HOME_TESTNET = 'https://testnet.steexp.com'
@@ -49,6 +50,7 @@ const NetworkSelector = ({
           Cookies.remove('sorobanRPCAddress')
 
           if (
+            isDecentralizedBuild ||
             window.location.hostname === 'localhost' ||
             window.location.hostname === '127.0.0.1'
           ) {

--- a/app/components/layout/ThemeSwitcher.tsx
+++ b/app/components/layout/ThemeSwitcher.tsx
@@ -1,4 +1,5 @@
 import { Theme, useTheme } from '~/context/theme.provider'
+import { publicAssetUrl } from '~/lib/build-target'
 
 const ThemeSwitcher = () => {
   const [theme, setTheme] = useTheme()
@@ -16,11 +17,20 @@ const ThemeSwitcher = () => {
 }
 
 const DarkIcon = () => {
-  return <img src="/img/moon.svg" alt="moon" width={28} height={28} />
+  return (
+    <img
+      src={publicAssetUrl('img/moon.svg')}
+      alt="moon"
+      width={28}
+      height={28}
+    />
+  )
 }
 
 const LightIcon = () => {
-  return <img src="/img/sun.svg" alt="sun" width={28} height={28} />
+  return (
+    <img src={publicAssetUrl('img/sun.svg')} alt="sun" width={28} height={28} />
+  )
 }
 
 export default ThemeSwitcher

--- a/app/components/shared/Logo.tsx
+++ b/app/components/shared/Logo.tsx
@@ -1,4 +1,5 @@
 import type { KnownAccountType } from '~/data/known_accounts'
+import { publicAssetUrl } from '~/lib/build-target'
 
 // 2 supported logo forms
 const squareDimensions = { height: 75, width: 75 }
@@ -15,7 +16,7 @@ export default function Logo({
   type: KnownAccountType
 }>) {
   const nameLower = name?.toLowerCase() ?? ''
-  const imgSrc = `/img/${nameLower}.png`
+  const imgSrc = publicAssetUrl(`img/${nameLower}.png`)
   const dimen =
     type !== 'exchange' || imagesInBoth.indexOf(nameLower) !== -1
       ? squareDimensions

--- a/app/lib/build-target.ts
+++ b/app/lib/build-target.ts
@@ -1,0 +1,28 @@
+type BuildTarget = 'centralized' | 'decentralized'
+
+declare const __STEEXP_BUILD_TARGET__: BuildTarget | undefined
+
+const buildTarget: BuildTarget =
+  typeof __STEEXP_BUILD_TARGET__ === 'string'
+    ? __STEEXP_BUILD_TARGET__
+    : 'centralized'
+
+const isDecentralizedBuild = buildTarget === 'decentralized'
+
+const publicAssetUrl = (path: string): string => {
+  const normalizedPath = path.startsWith('/') ? path.slice(1) : path
+
+  if (isDecentralizedBuild && typeof window !== 'undefined') {
+    return new URL(normalizedPath, `${window.location.origin}/`).toString()
+  }
+
+  if (isDecentralizedBuild) {
+    return `./${normalizedPath}`
+  }
+
+  const baseUrl = import.meta.env.BASE_URL || '/'
+  const normalizedBase = baseUrl.endsWith('/') ? baseUrl : `${baseUrl}/`
+  return `${normalizedBase}${normalizedPath}`
+}
+
+export { buildTarget, isDecentralizedBuild, publicAssetUrl }

--- a/app/lib/build-target.ts
+++ b/app/lib/build-target.ts
@@ -20,9 +20,7 @@ const publicAssetUrl = (path: string): string => {
     return `./${normalizedPath}`
   }
 
-  const baseUrl = import.meta.env.BASE_URL || '/'
-  const normalizedBase = baseUrl.endsWith('/') ? baseUrl : `${baseUrl}/`
-  return `${normalizedBase}${normalizedPath}`
+  return `/${normalizedPath}`
 }
 
 export { buildTarget, isDecentralizedBuild, publicAssetUrl }

--- a/app/lib/stellar/__tests__/networks.test.ts
+++ b/app/lib/stellar/__tests__/networks.test.ts
@@ -14,10 +14,10 @@ describe('hostnameToNetwork', () => {
     expect(hostnameToNetworkType('publicnet.local')).toEqual(networks.public)
     expect(hostnameToNetworkType('futurenet.local')).toEqual(networks.future)
 
-    // unknown hosts default to local
-    expect(hostnameToNetworkType('')).toEqual(networks.local)
+    // unknown hosts default to public for decentralized/root-style gateways
+    expect(hostnameToNetworkType('')).toEqual(networks.public)
     expect(hostnameToNetworkType('localhost')).toEqual(networks.public)
     expect(hostnameToNetworkType('0.0.0.0')).toEqual(networks.local)
-    expect(hostnameToNetworkType('not.steexp.com')).toEqual(networks.local)
+    expect(hostnameToNetworkType('not.steexp.com')).toEqual(networks.public)
   })
 })

--- a/app/lib/stellar/networks.ts
+++ b/app/lib/stellar/networks.ts
@@ -83,8 +83,10 @@ const hostnameToNetworkType = (hostname: string) => {
     hostname === 'futurenet.local'
   ) {
     return networks.future
-  } else {
+  } else if (hostname === 'localnet.local' || hostname === '0.0.0.0') {
     return networks.local
+  } else {
+    return networks.public
   }
 }
 

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -43,13 +43,16 @@ import SearchBox from './SearchBox'
 import { NotFoundError } from '@stellar/stellar-sdk'
 import { ThemeProvider, useTheme } from '~/context/theme.provider'
 import type { ErrorBoundaryComponent } from '@remix-run/react/dist/routeModules'
+import { publicAssetUrl } from './lib/build-target'
 
 export const links: LinksFunction = () => [
-  { rel: 'stylesheet', href: bootstrapStyles },
-  { rel: 'stylesheet', href: jsonPrettyStyles },
-  { rel: 'stylesheet', href: siteStyles },
-  { rel: 'stylesheet', href: lightSiteStyles },
-  ...(cssBundleHref ? [{ rel: 'stylesheet', href: cssBundleHref }] : []),
+  { rel: 'stylesheet', href: publicAssetUrl(bootstrapStyles) },
+  { rel: 'stylesheet', href: publicAssetUrl(jsonPrettyStyles) },
+  { rel: 'stylesheet', href: publicAssetUrl(siteStyles) },
+  { rel: 'stylesheet', href: publicAssetUrl(lightSiteStyles) },
+  ...(cssBundleHref
+    ? [{ rel: 'stylesheet', href: publicAssetUrl(cssBundleHref) }]
+    : []),
 ]
 
 // const storage = storageInit()
@@ -100,11 +103,11 @@ function HtmlDocument({
           name="viewport"
           content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=0"
         />
-        <link rel="shortcut icon" href="/favicon.ico" />
-        <link rel="manifest" href="/manifest.json" />
+        <link rel="shortcut icon" href={publicAssetUrl('favicon.ico')} />
+        <link rel="manifest" href={publicAssetUrl('manifest.json')} />
         <link
           rel="search"
-          href="/search.xml"
+          href={publicAssetUrl('search.xml')}
           title="Stellar Explorer"
           type="application/opensearchdescription+xml"
         />
@@ -190,8 +193,8 @@ export function HydrateFallback() {
           name="viewport"
           content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=0"
         />
-        <link rel="shortcut icon" href="/favicon.ico" />
-        <link rel="manifest" href="/manifest.json" />
+        <link rel="shortcut icon" href={publicAssetUrl('favicon.ico')} />
+        <link rel="manifest" href={publicAssetUrl('manifest.json')} />
         <Meta />
         <Links />
         <script

--- a/app/routes/lib/assets-base.tsx
+++ b/app/routes/lib/assets-base.tsx
@@ -1,7 +1,6 @@
 import { useEffect } from 'react'
 import { Card, Container, Row, Table } from 'react-bootstrap'
 import { FormattedMessage, useIntl } from 'react-intl'
-const svgCircle = '/img/circle.svg'
 
 import { setTitle } from '../../lib/utils'
 import BackendResourceBadgeButton from '../../components/shared/BackendResourceBadgeButton'
@@ -9,6 +8,9 @@ import NewWindowIcon from '../../components/shared/NewWindowIcon'
 import { TitleWithJSONButton } from '~/components/shared/TitleWithJSONButton'
 import styles from './assets-base.module.css'
 import { formatPercentToHumanReadable, formatPrice24h } from '~/lib/utilities'
+import { publicAssetUrl } from '~/lib/build-target'
+
+const svgCircle = publicAssetUrl('img/circle.svg')
 
 export const METADATA_URI =
   'https://raw.githubusercontent.com/irisli/stellarterm/master/directory/directory.json'

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "sideEffects": false,
   "scripts": {
     "build": "remix vite:build",
+    "build:decentralized": "STEEXP_BUILD_TARGET=decentralized remix vite:build && node scripts/patch-decentralized-remix-manifest.mjs",
     "dev": "remix vite:dev",
     "start": "vite preview",
     "pages:dev": "wrangler pages dev ./build/client",

--- a/scripts/patch-decentralized-remix-manifest.mjs
+++ b/scripts/patch-decentralized-remix-manifest.mjs
@@ -1,0 +1,17 @@
+import { readFile, readdir, writeFile } from 'node:fs/promises'
+import path from 'node:path'
+
+const assetsDir = path.join(process.cwd(), 'build', 'client', 'assets')
+const files = await readdir(assetsDir)
+const manifestFile = files.find((file) => /^manifest-[a-f0-9]+\.js$/.test(file))
+
+if (!manifestFile) {
+  throw new Error(`No Remix browser manifest found in ${assetsDir}`)
+}
+
+const manifestPath = path.join(assetsDir, manifestFile)
+const source = await readFile(manifestPath, 'utf8')
+const patched = source.replaceAll('"./assets/', '"/assets/')
+
+await writeFile(manifestPath, patched)
+console.log(`Patched decentralized Remix manifest: ${manifestPath}`)

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,7 +3,16 @@ import { defineConfig } from 'vite'
 import tsconfigPaths from 'vite-tsconfig-paths'
 import { nodePolyfills } from 'vite-plugin-node-polyfills'
 
+const buildTarget =
+  process.env.STEEXP_BUILD_TARGET === 'decentralized'
+    ? 'decentralized'
+    : 'centralized'
+
 export default defineConfig({
+  base: buildTarget === 'decentralized' ? './' : '/',
+  define: {
+    __STEEXP_BUILD_TARGET__: JSON.stringify(buildTarget),
+  },
   server: {
     port: 3000,
     allowedHosts: ['publicnet.local', 'testnet.local', 'futurenet.local'],


### PR DESCRIPTION
## Summary
- keep the existing Cloudflare Pages build as the default centralized target
- add pnpm build:decentralized for root-style decentralized gateways
- make public asset URLs static-safe and keep decentralized network switching on-origin
- document IPFS DNSLink/subdomain and Arweave/ArNS deployment flows

## Security / sensitivity
- no secrets, wallet files, private keys, or tokens are included
- Arweave docs use placeholder values only, e.g. /path/to/arweave-wallet.json
- existing API URL remains the public steexp-api.fly.dev endpoint

## Verification
- pnpm build
- pnpm build:decentralized
- pnpm lint
- pnpm test
- checked decentralized build/client/index.html for root-absolute href/src app asset refs